### PR TITLE
Fix product search bug in ChatPage

### DIFF
--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -300,10 +300,14 @@ const ChatPage = ({ user, onLogout }) => {
   };
 
   const handleProductSearch = () => {
-    const found = products.find(
-      (p) =>
-        (p.title || p.productName || "").toLowerCase() ===
-        searchTitle.trim().toLowerCase()
+    const query = searchTitle.trim().toLowerCase();
+    if (!query) {
+      setSearchResult(null);
+      return;
+    }
+
+    const found = products.find((p) =>
+      (p.title || p.productName || "").toLowerCase().includes(query)
     );
     setSearchResult(found || null);
   };


### PR DESCRIPTION
## Summary
- improve product search handling in ChatPage so empty queries reset results and partial matches work

## Testing
- `npm run build` *(fails: vite: Permission denied)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6852d74e667483299201b69d9c41bbc2